### PR TITLE
Fix - Add EncounterMonster Index to Create Encounter Mutation

### DIFF
--- a/app/graphql/mutations/create_encounter.rb
+++ b/app/graphql/mutations/create_encounter.rb
@@ -21,9 +21,10 @@ class Mutations::CreateEncounter < Mutations::BaseMutation
                               user_name: input[:user_name])
 
     if encounter.save
-      encounter_monsters = input[:encounterMonsters]
-      encounter_monsters.each do |monster_name|
-        EncounterMonster.create!(encounter_id: encounter.id, monster_name: monster_name)
+      input[:encounterMonsters].each do |monster_index|
+        EncounterMonster.create!(encounter_id: encounter.id,
+                                monster_name: monster_index.capitalize,
+                                monster_index: monster_index)
       end
       { encounter: encounter, errors: [] }
     else

--- a/app/graphql/mutations/create_encounter.rb
+++ b/app/graphql/mutations/create_encounter.rb
@@ -5,7 +5,7 @@ class Mutations::CreateEncounter < Mutations::BaseMutation
   argument :summary, String, required: false
   argument :description, String, required: false
   argument :treasure, String, required: false
-  argument :encounterMonsters, [String], required: true
+  argument :encounterMonsterIndexes, [String], required: true
   argument :user_name, String, required: true
 
   field :encounter, Types::EncounterType, null: false
@@ -23,7 +23,7 @@ class Mutations::CreateEncounter < Mutations::BaseMutation
     if encounter.save
       input[:encounterMonsters].each do |monster_index|
         EncounterMonster.create!(encounter_id: encounter.id,
-                                monster_name: monster_index.capitalize,
+                                monster_name: monster_index..gsub('-', ' ').titleize,
                                 monster_index: monster_index)
       end
       { encounter: encounter, errors: [] }

--- a/app/graphql/mutations/create_encounter.rb
+++ b/app/graphql/mutations/create_encounter.rb
@@ -21,9 +21,9 @@ class Mutations::CreateEncounter < Mutations::BaseMutation
                               user_name: input[:user_name])
 
     if encounter.save
-      input[:encounterMonsters].each do |monster_index|
+      input[:encounterMonsterIndexes].each do |monster_index|
         EncounterMonster.create!(encounter_id: encounter.id,
-                                monster_name: monster_index..gsub('-', ' ').titleize,
+                                monster_name: monster_index.gsub('-', ' ').titleize,
                                 monster_index: monster_index)
       end
       { encounter: encounter, errors: [] }

--- a/spec/graphql/mutations/requests/create_encounter_spec.rb
+++ b/spec/graphql/mutations/requests/create_encounter_spec.rb
@@ -21,13 +21,13 @@ module Mutations
           expect(encounter['description']).to eq('Monster party!')
           expect(encounter['treasure']).to eq('We not deserve anything')
           expect(encounter['encounterMonsters']).to eq([{
-                                                          "monsterName": "Beholder", 
-                                                          "monsterIndex": "beholder"
+                                                          "monsterName"=>"Beholder", 
+                                                          "monsterIndex"=>"beholder"
                                                         }, 
                                                         {
-                                                          "monsterName": "Goblin", 
-                                                          "monsterIndex": "goblin"
-                                                          }])
+                                                          "monsterName"=>"Goblin", 
+                                                          "monsterIndex"=>"goblin"
+                                                        }])
           expect(encounter['userName']).to eq('Shrek')
         end
       end
@@ -48,7 +48,6 @@ module Mutations
             encounter {
               id
               encounterName
-              encounterIndex
               partySize
               partyLevel
               summary

--- a/spec/graphql/mutations/requests/create_encounter_spec.rb
+++ b/spec/graphql/mutations/requests/create_encounter_spec.rb
@@ -20,7 +20,14 @@ module Mutations
           expect(encounter['summary']).to eq('I hope this works')
           expect(encounter['description']).to eq('Monster party!')
           expect(encounter['treasure']).to eq('We not deserve anything')
-          expect(encounter['encounterMonsters']).to eq([{"monsterName"=>"beholder"}, {"monsterName"=>"goblin"}])
+          expect(encounter['encounterMonsters']).to eq([{
+                                                          "monsterName": "Beholder", 
+                                                          "monsterIndex": "beholder"
+                                                        }, 
+                                                        {
+                                                          "monsterName": "Goblin", 
+                                                          "monsterIndex": "goblin"
+                                                          }])
           expect(encounter['userName']).to eq('Shrek')
         end
       end
@@ -41,6 +48,7 @@ module Mutations
             encounter {
               id
               encounterName
+              encounterIndex
               partySize
               partyLevel
               summary
@@ -48,6 +56,7 @@ module Mutations
               treasure
               encounterMonsters {
                 monsterName
+                monsterIndex
               }
               userName
             }

--- a/spec/graphql/mutations/requests/create_encounter_spec.rb
+++ b/spec/graphql/mutations/requests/create_encounter_spec.rb
@@ -42,7 +42,7 @@ module Mutations
               summary: "I hope this works",
               description: "Monster party!",
               treasure: "We not deserve anything",
-              encounterMonsters: ["beholder", "goblin"]
+              encounterMonsterIndexes: ["beholder", "goblin"]
               userName: "Shrek"
             }) {
             encounter {


### PR DESCRIPTION
# Description
This branch adds logic to the create encounter mutation to create encounter_monster index for each index provided in addition to populating monster_name. 

# Checklist
- [x] My PR has an appropriately descriptive and concise title.
- [x] I ran the code locally and verified that there are no visible errors.
- [x] fix: My PR clearly describes the bug I'm fixing and why.
